### PR TITLE
Add the heap data-structure

### DIFF
--- a/contracts/Heap.sol
+++ b/contracts/Heap.sol
@@ -123,8 +123,10 @@ library BasicHeap {
             maxIndex = _index;
             maxValue = _heap.accounts[_index - 1].value;
 
-            if (leftIndex <= accountsLength && _heap.accounts[leftIndex - 1].value > maxValue)
+            if (leftIndex <= accountsLength && _heap.accounts[leftIndex - 1].value > maxValue) {
                 maxIndex = leftIndex;
+                maxValue = _heap.accounts[leftIndex - 1].value;
+            }
 
             if (rightIndex <= accountsLength && _heap.accounts[rightIndex - 1].value > maxValue)
                 maxIndex = rightIndex;

--- a/contracts/Heap.sol
+++ b/contracts/Heap.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.8.0;
 
 library BasicHeap {
     struct Account {
-        address id;
-        uint256 value;
+        address id; // The address of the account.
+        uint256 value; // The value of the account.
     }
 
     struct Heap {
-        Account[] accounts;
-        mapping(address => uint256) indexes;
+        Account[] accounts; // All the accounts.
+        mapping(address => uint256) ranks; // A mapping from an address to a rank in accounts. Beware: ranks are shifted by one compared to indexes, so the first rank is 1 and not 0.
     }
 
     /// ERRORS ///
@@ -17,209 +17,14 @@ library BasicHeap {
     /// @notice Thrown when the address is zero at insertion.
     error AddressIsZero();
 
-    /// VIEW ///
-
-    /// @notice Returns the length of the `_heap`.
-    /// @param _heap The heap parameter.
-    /// @return The length of the heap.
-    function length(Heap storage _heap) internal view returns (uint256) {
-        return _heap.accounts.length;
-    }
-
-    /// @notice Returns the value of the account linked to `_id`.
-    /// @param _heap The heap to search in.
-    /// @param _id The address of the account.
-    /// @return The value of the account.
-    function getValueOf(Heap storage _heap, address _id) internal view returns (uint256) {
-        uint256 index = _heap.indexes[_id];
-        if (index == 0) return 0;
-        else return _heap.accounts[index - 1].value;
-    }
-
-    /// @notice Returns the address at the head of the `_heap`.
-    /// @param _heap The heap to get the head.
-    /// @return The address of the head.
-    function getHead(Heap storage _heap) internal view returns (address) {
-        if (_heap.accounts.length > 0) return _heap.accounts[0].id;
-        else return address(0);
-    }
-
-    /// @notice Returns the address at the tail of the `_heap`.
-    /// @param _heap The heap to get the tail.
-    /// @return The address of the tail.
-    function getTail(Heap storage _heap) internal view returns (address) {
-        if (_heap.accounts.length > 0) return _heap.accounts[_heap.accounts.length - 1].id;
-        else return address(0);
-    }
-
-    /// @notice Returns the previous address from the current `_id`.
-    /// @param _heap The heap to search in.
-    /// @param _id The address of the account.
-    /// @return The address of the previous account.
-    function getPrev(Heap storage _heap, address _id) internal view returns (address) {
-        uint256 index = _heap.indexes[_id];
-        if (index > 1) return _heap.accounts[index - 2].id;
-        else return address(0);
-    }
-
-    /// @notice Returns the next address from the current `_id`.
-    /// @param _heap The heap to search in.
-    /// @param _id The address of the account.
-    /// @return The address of the next account.
-    function getNext(Heap storage _heap, address _id) internal view returns (address) {
-        uint256 index = _heap.indexes[_id];
-        if (index < _heap.accounts.length) return _heap.accounts[index].id;
-        else return address(0);
-    }
-
-    /// PRIVATE ///
-
-    /// @notice Sets `_index` in the `_heap` to be `_account`.
-    /// @dev The heap may lose its invariant about the order of the values stored.
-    /// @dev Only call this function with an index in the bounds of the array.
-    /// @param _heap The heap to modify.
-    /// @param _index The index of the account in the heap to be set.
-    /// @param _account The account to set the `_index` to.
-    function set(
-        Heap storage _heap,
-        uint256 _index,
-        Account memory _account
-    ) private {
-        _heap.accounts[_index - 1] = _account;
-        _heap.indexes[_account.id] = _index;
-    }
-
-    /// @notice Swaps two accounts in the `_heap`.
-    /// @dev The heap may lose its invariant about the order of the values stored.
-    /// @dev Only call this function with indexes in the bounds of the array.
-    /// @param _heap The heap to modify.
-    /// @param _index1 The index of the first account in the heap.
-    /// @param _index2 The index of the second account in the heap.
-    function swap(
-        Heap storage _heap,
-        uint256 _index1,
-        uint256 _index2
-    ) private {
-        Account memory accountOldIndex1 = _heap.accounts[_index1 - 1];
-        Account memory accountOldIndex2 = _heap.accounts[_index2 - 1];
-        set(_heap, _index1, accountOldIndex2);
-        set(_heap, _index2, accountOldIndex1);
-    }
-
-    /// @notice Moves an account up the heap until its value is smaller than the one of its parent.
-    /// @dev This functions restores the invariant about the order of the values stored when the account at `_index` is the only one with value greater than what it should be.
-    /// @param _heap The heap to modify.
-    /// @param _index The index of the account to move.
-    function shiftUp(Heap storage _heap, uint256 _index) private {
-        Account memory initAccount = _heap.accounts[_index - 1];
-        uint256 initValue = initAccount.value;
-        while (_index != 1 && initValue > _heap.accounts[_index / 2 - 1].value) {
-            set(_heap, _index, _heap.accounts[_index / 2 - 1]);
-            _index /= 2;
-        }
-        set(_heap, _index, initAccount);
-    }
-
-    /// @notice Moves an account down the heap until its value is greater than the ones of its children.
-    /// @dev This functions restores the invariant about the order of the values stored when the account at `_index` is the only one with value smaller than what it should be.
-    /// @param _heap The heap to modify.
-    /// @param _index The index of the account to move.
-    function shiftDown(Heap storage _heap, uint256 _index) private {
-        uint256 size = _heap.accounts.length;
-        Account memory initAccount = _heap.accounts[_index - 1];
-        uint256 childIndex = _index * 2;
-        Account memory childAccount;
-
-        while (childIndex <= size) {
-            if (
-                childIndex + 1 <= size &&
-                _heap.accounts[childIndex].value > _heap.accounts[childIndex - 1].value
-            ) childIndex++;
-
-            childAccount = _heap.accounts[childIndex - 1];
-
-            if (childAccount.value > initAccount.value) {
-                set(_heap, _index, childAccount);
-                _index = childIndex;
-                childIndex *= 2;
-            } else break;
-        }
-        set(_heap, _index, initAccount);
-    }
-
-    /// @notice Inserts an account in the `_heap`.
-    /// @dev Only call this function when `_id`.
-    /// @dev Reverts with AddressIsZero if `_value` is 0.
-    /// @param _heap The heap to modify.
-    /// @param _id The address of the account to insert.
-    /// @param _value The value of the account to insert.
-    function insert(
-        Heap storage _heap,
-        address _id,
-        uint256 _value
-    ) private {
-        // _heap cannot contain the 0 address
-        if (_id == address(0)) revert AddressIsZero();
-        _heap.accounts.push(Account(_id, _value));
-        uint256 accountsLength = _heap.accounts.length;
-        _heap.indexes[_id] = accountsLength;
-        shiftUp(_heap, accountsLength);
-    }
-
-    /// @notice Decreases the amount of an account in the `_heap`.
-    /// @dev Only call this function when `_id` is in the `_heap` with a value greater than `_newValue`.
-    /// @param _heap The heap to modify.
-    /// @param _id The address of the account to decrease the amount.
-    /// @param _newValue The new value of the account.
-    function decrease(
-        Heap storage _heap,
-        address _id,
-        uint256 _newValue
-    ) private {
-        uint256 index = _heap.indexes[_id];
-        _heap.accounts[index - 1].value = _newValue;
-        shiftDown(_heap, index);
-    }
-
-    /// @notice Increases the amount of an account in the `_heap`.
-    /// @dev Only call this function when `_id` is in the `_heap` with a smaller value than `_newValue`.
-    /// @param _heap The heap to modify.
-    /// @param _id The address of the account to increase the amount.
-    /// @param _newValue The new value of the account.
-    function increase(
-        Heap storage _heap,
-        address _id,
-        uint256 _newValue
-    ) private {
-        uint256 index = _heap.indexes[_id];
-        _heap.accounts[index - 1].value = _newValue;
-        shiftUp(_heap, index);
-    }
-
-    /// @notice Removes an account in the `_heap`.
-    /// @dev Only call when `_id` is in the `_heap`.
-    /// @param _heap The heap to modify.
-    /// @param _id The address of the account to remove.
-    function remove(Heap storage _heap, address _id) private {
-        uint256 index = _heap.indexes[_id];
-        uint256 accountsLength = _heap.accounts.length;
-        if (index == accountsLength) {
-            _heap.accounts.pop();
-            delete _heap.indexes[_id];
-        } else {
-            swap(_heap, index, accountsLength);
-            _heap.accounts.pop();
-            delete _heap.indexes[_id];
-            shiftDown(_heap, index);
-        }
-    }
-
     /// INTERNAL ///
 
-    /// @notice Removes an account in the `_heap`.
-    /// @dev Only call with `_id` is in the `_heap` with value `_formerValue`.
+    /// @notice Updates an account in the `_heap`.
+    /// @dev Only call with `_id` is in the `_heap` with value `_formerValue` or when `_id` is not in the `_heap` with `_formerValue` equal to 0.
     /// @param _heap The heap to modify.
-    /// @param _id The address of the account to remove.
+    /// @param _id The address of the account to update.
+    /// @param _formerValue The former value of the account to update.
+    /// @param _newValue The new value of the account to update.
     function update(
         Heap storage _heap,
         address _id,
@@ -232,5 +37,237 @@ library BasicHeap {
             else if (_formerValue < _newValue) increase(_heap, _id, _newValue);
             else decrease(_heap, _id, _newValue);
         }
+    }
+
+    /// PRIVATE ///
+
+    /// @notice Returns the account of rank `_rank`.
+    /// @dev The first rank is 1 and the last one is the size of the heap.
+    /// @dev Only call this function with positive numbers.
+    /// @param _heap The heap to search in.
+    /// @param _rank The rank of the account.
+    /// @return The account of rank `_rank`.
+    function getAccount(Heap storage _heap, uint256 _rank) private view returns (Account storage) {
+        return _heap.accounts[_rank - 1];
+    }
+
+    /// @notice Sets `_index` in the `_heap` to be `_account`.
+    /// @dev The heap may lose its invariant about the order of the values stored.
+    /// @dev Only call this function with a rank within array's bounds.
+    /// @param _heap The heap to modify.
+    /// @param _rank The rank of the account in the heap to be set.
+    /// @param _account The account to set the `_rank` to.
+    function setAccount(
+        Heap storage _heap,
+        uint256 _rank,
+        Account memory _account
+    ) private {
+        _heap.accounts[_rank - 1] = _account;
+        _heap.ranks[_account.id] = _rank;
+    }
+
+    /// @notice Sets the value at `_rank` in the `_heap` to be `_newValue`.
+    /// @dev The heap may lose its invariant about the order of the values stored.
+    /// @dev Only call this function with a rank within array's bounds.
+    /// @param _heap The heap to modify.
+    /// @param _rank The rank of the account in the heap to be set.
+    /// @param _newValue The new value to set the `_rank` to.
+    function setAccountValue(
+        Heap storage _heap,
+        uint256 _rank,
+        uint256 _newValue
+    ) private {
+        _heap.accounts[_rank - 1].value = _newValue;
+    }
+
+    /// @notice Swaps two accounts in the `_heap`.
+    /// @dev The heap may lose its invariant about the order of the values stored.
+    /// @dev Only call this function with ranks within array's bounds.
+    /// @param _heap The heap to modify.
+    /// @param _rank1 The rank of the first account in the heap.
+    /// @param _rank2 The rank of the second account in the heap.
+    function swap(
+        Heap storage _heap,
+        uint256 _rank1,
+        uint256 _rank2
+    ) private {
+        Account memory accountOldRank1 = getAccount(_heap, _rank1);
+        Account memory accountOldRank2 = getAccount(_heap, _rank2);
+        setAccount(_heap, _rank1, accountOldRank2);
+        setAccount(_heap, _rank2, accountOldRank1);
+    }
+
+    /// @notice Moves an account up the heap until its value is smaller than the one of its parent.
+    /// @dev This functions restores the invariant about the order of the values stored when the account at `_rank` is the only one with value greater than what it should be.
+    /// @param _heap The heap to modify.
+    /// @param _rank The index of the account to move.
+    function shiftUp(Heap storage _heap, uint256 _rank) private {
+        Account memory initialAccount = getAccount(_heap, _rank);
+        uint256 initialValue = initialAccount.value;
+        while (_rank > 1 && initialValue > getAccount(_heap, _rank / 2).value) {
+            setAccount(_heap, _rank, getAccount(_heap, _rank / 2));
+            _rank /= 2;
+        }
+        setAccount(_heap, _rank, initialAccount);
+    }
+
+    /// @notice Moves an account down the heap until its value is greater than the ones of its children.
+    /// @dev This functions restores the invariant about the order of the values stored when the account at `_rank` is the only one with value smaller than what it should be.
+    /// @param _heap The heap to modify.
+    /// @param _rank The index of the account to move.
+    function shiftDown(Heap storage _heap, uint256 _rank) private {
+        uint256 size = getSize(_heap);
+        Account memory initialAccount = getAccount(_heap, _rank);
+        uint256 initialValue = initialAccount.value;
+        Account memory childAccount;
+        uint256 childRank = _rank * 2;
+        // At this point, childRank (resp. childRank+1) is the rank of the left (resp. right) child.
+
+        while (childRank <= size) {
+            // Compute the rank of the child with largest value.
+            if (
+                childRank < size &&
+                getAccount(_heap, childRank + 1).value > getAccount(_heap, childRank).value
+            ) childRank++;
+
+            childAccount = getAccount(_heap, childRank);
+
+            if (childAccount.value > initialValue) {
+                setAccount(_heap, _rank, childAccount);
+                _rank = childRank;
+                childRank *= 2;
+            } else break;
+        }
+        setAccount(_heap, _rank, initialAccount);
+    }
+
+    /// @notice Inserts an account in the `_heap`.
+    /// @dev Only call this function when `_id` is not in the `_heap`.
+    /// @dev Reverts with AddressIsZero if `_value` is 0.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to insert.
+    /// @param _value The value of the account to insert.
+    function insert(
+        Heap storage _heap,
+        address _id,
+        uint256 _value
+    ) private {
+        // _heap cannot contain the 0 address
+        if (_id == address(0)) revert AddressIsZero();
+
+        // Put the account at the end of the heap.
+        _heap.accounts.push(Account(_id, _value));
+        uint256 size = getSize(_heap);
+        _heap.ranks[_id] = size;
+
+        // Restore the invariant.
+        shiftUp(_heap, size);
+    }
+
+    /// @notice Decreases the amount of an account in the `_heap`.
+    /// @dev Only call this function when `_id` is in the `_heap` with a value greater than `_newValue`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to decrease the amount.
+    /// @param _newValue The new value of the account.
+    function decrease(
+        Heap storage _heap,
+        address _id,
+        uint256 _newValue
+    ) private {
+        uint256 rank = _heap.ranks[_id];
+        setAccountValue(_heap, rank, _newValue);
+        shiftDown(_heap, rank);
+    }
+
+    /// @notice Increases the amount of an account in the `_heap`.
+    /// @dev Only call this function when `_id` is in the `_heap` with a smaller value than `_newValue`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to increase the amount.
+    /// @param _newValue The new value of the account.
+    function increase(
+        Heap storage _heap,
+        address _id,
+        uint256 _newValue
+    ) private {
+        uint256 rank = _heap.ranks[_id];
+        setAccountValue(_heap, rank, _newValue);
+        shiftUp(_heap, rank);
+    }
+
+    /// @notice Removes an account in the `_heap`.
+    /// @dev Only call when `_id` is in the `_heap`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to remove.
+    function remove(Heap storage _heap, address _id) private {
+        uint256 rank = _heap.ranks[_id];
+        uint256 removedValue = getAccount(_heap, rank).value;
+        uint256 size = getSize(_heap);
+
+        if (rank == size) {
+            _heap.accounts.pop();
+            delete _heap.ranks[_id];
+        } else {
+            swap(_heap, rank, size);
+            _heap.accounts.pop();
+            delete _heap.ranks[_id];
+            if (getAccount(_heap, rank).value > removedValue) shiftUp(_heap, rank);
+            else shiftDown(_heap, rank);
+        }
+    }
+
+    /// VIEW ///
+
+    /// @notice Returns the size of the `_heap`.
+    /// @param _heap The heap parameter.
+    /// @return The size of the heap.
+    function getSize(Heap storage _heap) internal view returns (uint256) {
+        return _heap.accounts.length;
+    }
+
+    /// @notice Returns the value of the account linked to `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The value of the account.
+    function getValueOf(Heap storage _heap, address _id) internal view returns (uint256) {
+        uint256 rank = _heap.ranks[_id];
+        if (rank == 0) return 0;
+        else return getAccount(_heap, rank).value;
+    }
+
+    /// @notice Returns the address at the head of the `_heap`.
+    /// @param _heap The heap to get the head.
+    /// @return The address of the head.
+    function getHead(Heap storage _heap) internal view returns (address) {
+        if (getSize(_heap) > 0) return getAccount(_heap, 1).id;
+        else return address(0);
+    }
+
+    /// @notice Returns the address at the tail of the `_heap`.
+    /// @param _heap The heap to get the tail.
+    /// @return The address of the tail.
+    function getTail(Heap storage _heap) internal view returns (address) {
+        uint256 size = getSize(_heap);
+        if (size > 0) return getAccount(_heap, size).id;
+        else return address(0);
+    }
+
+    /// @notice Returns the previous address from the current `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The address of the previous account.
+    function getPrev(Heap storage _heap, address _id) internal view returns (address) {
+        uint256 rank = _heap.ranks[_id];
+        if (rank > 1) return getAccount(_heap, rank - 1).id;
+        else return address(0);
+    }
+
+    /// @notice Returns the next address from the current `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The address of the next account.
+    function getNext(Heap storage _heap, address _id) internal view returns (address) {
+        uint256 rank = _heap.ranks[_id];
+        if (rank < getSize(_heap)) return getAccount(_heap, rank + 1).id;
+        else return address(0);
     }
 }

--- a/contracts/Heap.sol
+++ b/contracts/Heap.sol
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+library BasicHeap {
+    struct Account {
+        address id;
+        uint256 value;
+    }
+
+    struct Heap {
+        Account[] accounts;
+        mapping(address => uint256) indexes;
+    }
+
+    /// ERRORS ///
+
+    /// @notice Thrown when the address is zero at insertion.
+    error AddressIsZero();
+
+    /// VIEW ///
+
+    /// @notice Returns the length of the `_heap`.
+    /// @param _heap The heap parameter.
+    /// @return The length of the heap.
+    function length(Heap storage _heap) internal view returns (uint256) {
+        return _heap.accounts.length;
+    }
+
+    /// @notice Returns the value of the account linked to `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The value of the account.
+    function getValueOf(Heap storage _heap, address _id) internal view returns (uint256) {
+        uint256 index = _heap.indexes[_id];
+        if (index == 0) return 0;
+        else return _heap.accounts[index - 1].value;
+    }
+
+    /// @notice Returns the address at the head of the `_heap`.
+    /// @param _heap The heap to get the head.
+    /// @return The address of the head.
+    function getHead(Heap storage _heap) internal view returns (address) {
+        if (_heap.accounts.length > 0) return _heap.accounts[0].id;
+        else return address(0);
+    }
+
+    /// @notice Returns the address at the tail of the `_heap`.
+    /// @param _heap The heap to get the tail.
+    /// @return The address of the tail.
+    function getTail(Heap storage _heap) internal view returns (address) {
+        if (_heap.accounts.length > 0) return _heap.accounts[_heap.accounts.length - 1].id;
+        else return address(0);
+    }
+
+    /// @notice Returns the previous address from the current `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The address of the previous account.
+    function getPrev(Heap storage _heap, address _id) internal view returns (address) {
+        uint256 index = _heap.indexes[_id];
+        if (index > 1) return _heap.accounts[index - 2].id;
+        else return address(0);
+    }
+
+    /// @notice Returns the next address from the current `_id`.
+    /// @param _heap The heap to search in.
+    /// @param _id The address of the account.
+    /// @return The address of the next account.
+    function getNext(Heap storage _heap, address _id) internal view returns (address) {
+        uint256 index = _heap.indexes[_id];
+        if (index < _heap.accounts.length) return _heap.accounts[index].id;
+        else return address(0);
+    }
+
+    /// PRIVATE ///
+
+    /// @notice Swaps two accounts in the `_heap`.
+    /// @dev The heap may lose its invariant about the order of the values stored.
+    /// @dev Only call this function with indexes in the bounds of the array.
+    /// @param _heap The heap to modify.
+    /// @param _index1 The index of the first account in the heap.
+    /// @param _index2 The index of the second account in the heap.
+    function swap(
+        Heap storage _heap,
+        uint256 _index1,
+        uint256 _index2
+    ) private {
+        Account memory accountOldIndex1 = _heap.accounts[_index1 - 1];
+        Account memory accountOldIndex2 = _heap.accounts[_index2 - 1];
+        _heap.accounts[_index1 - 1] = accountOldIndex2;
+        _heap.accounts[_index2 - 1] = accountOldIndex1;
+        _heap.indexes[accountOldIndex2.id] = _index1;
+        _heap.indexes[accountOldIndex1.id] = _index2;
+    }
+
+    /// @notice Moves an account up the heap until its value is smaller than its parent's.
+    /// @dev This functions restores the invariant about the order of the values stored when the account at `_index` is the only one with value greater than what it should be.
+    /// @param _heap The heap to modify.
+    /// @param _index The index of the account to move.
+    function shiftUp(Heap storage _heap, uint256 _index) private {
+        uint256 mother = _index / 2;
+        while (mother > 0 && _heap.accounts[_index - 1].value > _heap.accounts[mother - 1].value) {
+            swap(_heap, _index, mother);
+            _index = mother;
+            mother = mother / 2;
+        }
+    }
+
+    /// @notice Moves an account down the heap until its value is greater than the ones of its children.
+    /// @dev This functions restores the invariant about the order of the values stored when the account at `_index` is the only one with value smaller than what it should be.
+    /// @param _heap The heap to modify.
+    /// @param _index The index of the account to move.
+    function shiftDown(Heap storage _heap, uint256 _index) private {
+        uint256 accountsLength = _heap.accounts.length;
+        uint256 leftIndex;
+        uint256 rightIndex;
+        uint256 maxIndex;
+        uint256 maxValue;
+
+        while (true) {
+            leftIndex = 2 * _index;
+            rightIndex = 2 * _index + 1;
+            maxIndex = _index;
+            maxValue = _heap.accounts[_index - 1].value;
+
+            if (leftIndex <= accountsLength && _heap.accounts[leftIndex - 1].value > maxValue)
+                maxIndex = leftIndex;
+
+            if (rightIndex <= accountsLength && _heap.accounts[rightIndex - 1].value > maxValue)
+                maxIndex = rightIndex;
+
+            if (maxIndex != _index) {
+                swap(_heap, _index, maxIndex);
+                _index = maxIndex;
+            } else break;
+        }
+    }
+
+    /// @notice Inserts an account in the `_heap`.
+    /// @dev Only call this function when `_id`.
+    /// @dev Reverts with AddressIsZero if `_value` is 0.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to insert.
+    /// @param _value The value of the account to insert.
+    function insert(
+        Heap storage _heap,
+        address _id,
+        uint256 _value
+    ) private {
+        // _heap cannot contain the 0 address
+        if (_id == address(0)) revert AddressIsZero();
+        _heap.accounts.push(Account(_id, _value));
+        uint256 accountsLength = _heap.accounts.length;
+        _heap.indexes[_id] = accountsLength;
+        shiftUp(_heap, accountsLength);
+    }
+
+    /// @notice Increase the amount of an account in the `_heap`.
+    /// @dev Only call this function when `_id` is in the `_heap` with a value greater than `_newValue`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to decrease the amount.
+    /// @param _newValue The new value of the account.
+    function decrease(
+        Heap storage _heap,
+        address _id,
+        uint256 _newValue
+    ) private {
+        uint256 index = _heap.indexes[_id];
+        _heap.accounts[index - 1].value = _newValue;
+        shiftDown(_heap, index);
+    }
+
+    /// @notice Increase the amount of an account in the `_heap`.
+    /// @dev Only call this function when `_id` is in the `_heap` with a smaller value than `_newValue`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to increase the amount.
+    /// @param _newValue The new value of the account.
+    function increase(
+        Heap storage _heap,
+        address _id,
+        uint256 _newValue
+    ) private {
+        uint256 index = _heap.indexes[_id];
+        _heap.accounts[index - 1].value = _newValue;
+        shiftUp(_heap, index);
+    }
+
+    /// @notice Removes an account in the `_heap`.
+    /// @dev Only call when `_id` is in the `_heap`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to remove.
+    function remove(Heap storage _heap, address _id) private {
+        uint256 index = _heap.indexes[_id];
+        uint256 accountsLength = _heap.accounts.length;
+        if (index == accountsLength) {
+            _heap.accounts.pop();
+            delete _heap.indexes[_id];
+        } else {
+            swap(_heap, index, accountsLength);
+            _heap.accounts.pop();
+            delete _heap.indexes[_id];
+            shiftDown(_heap, index);
+        }
+    }
+
+    /// INTERNAL ///
+
+    /// @notice Removes an account in the `_heap`.
+    /// @dev Only call with `_id` is in the `_heap` with value `_formerValue`.
+    /// @param _heap The heap to modify.
+    /// @param _id The address of the account to remove.
+    function update(
+        Heap storage _heap,
+        address _id,
+        uint256 _formerValue,
+        uint256 _newValue
+    ) internal {
+        if (_formerValue != _newValue) {
+            if (_newValue == 0) remove(_heap, _id);
+            else if (_formerValue == 0) insert(_heap, _id, _newValue);
+            else if (_formerValue < _newValue) increase(_heap, _id, _newValue);
+            else decrease(_heap, _id, _newValue);
+        }
+    }
+}

--- a/contracts/Heap.sol
+++ b/contracts/Heap.sol
@@ -93,7 +93,7 @@ library BasicHeap {
         _heap.indexes[accountOldIndex1.id] = _index2;
     }
 
-    /// @notice Moves an account up the heap until its value is smaller than its parent's.
+    /// @notice Moves an account up the heap until its value is smaller than the one of its parent.
     /// @dev This functions restores the invariant about the order of the values stored when the account at `_index` is the only one with value greater than what it should be.
     /// @param _heap The heap to modify.
     /// @param _index The index of the account to move.
@@ -155,7 +155,7 @@ library BasicHeap {
         shiftUp(_heap, accountsLength);
     }
 
-    /// @notice Increase the amount of an account in the `_heap`.
+    /// @notice Decreases the amount of an account in the `_heap`.
     /// @dev Only call this function when `_id` is in the `_heap` with a value greater than `_newValue`.
     /// @param _heap The heap to modify.
     /// @param _id The address of the account to decrease the amount.
@@ -170,7 +170,7 @@ library BasicHeap {
         shiftDown(_heap, index);
     }
 
-    /// @notice Increase the amount of an account in the `_heap`.
+    /// @notice Increases the amount of an account in the `_heap`.
     /// @dev Only call this function when `_id` is in the `_heap` with a smaller value than `_newValue`.
     /// @param _heap The heap to modify.
     /// @param _id The address of the account to increase the amount.

--- a/contracts/Heap.sol
+++ b/contracts/Heap.sol
@@ -74,6 +74,21 @@ library BasicHeap {
 
     /// PRIVATE ///
 
+    /// @notice Sets `_index` in the `_heap` to be `_account`.
+    /// @dev The heap may lose its invariant about the order of the values stored.
+    /// @dev Only call this function with an index in the bounds of the array.
+    /// @param _heap The heap to modify.
+    /// @param _index The index of the account in the heap to be set.
+    /// @param _account The account to set the `_index` to.
+    function set(
+        Heap storage _heap,
+        uint256 _index,
+        Account memory _account
+    ) private {
+        _heap.accounts[_index - 1] = _account;
+        _heap.indexes[_account.id] = _index;
+    }
+
     /// @notice Swaps two accounts in the `_heap`.
     /// @dev The heap may lose its invariant about the order of the values stored.
     /// @dev Only call this function with indexes in the bounds of the array.
@@ -87,10 +102,8 @@ library BasicHeap {
     ) private {
         Account memory accountOldIndex1 = _heap.accounts[_index1 - 1];
         Account memory accountOldIndex2 = _heap.accounts[_index2 - 1];
-        _heap.accounts[_index1 - 1] = accountOldIndex2;
-        _heap.accounts[_index2 - 1] = accountOldIndex1;
-        _heap.indexes[accountOldIndex2.id] = _index1;
-        _heap.indexes[accountOldIndex1.id] = _index2;
+        set(_heap, _index1, accountOldIndex2);
+        set(_heap, _index2, accountOldIndex1);
     }
 
     /// @notice Moves an account up the heap until its value is smaller than the one of its parent.
@@ -98,12 +111,13 @@ library BasicHeap {
     /// @param _heap The heap to modify.
     /// @param _index The index of the account to move.
     function shiftUp(Heap storage _heap, uint256 _index) private {
-        uint256 mother = _index / 2;
-        while (mother > 0 && _heap.accounts[_index - 1].value > _heap.accounts[mother - 1].value) {
-            swap(_heap, _index, mother);
-            _index = mother;
-            mother = mother / 2;
+        Account memory initAccount = _heap.accounts[_index - 1];
+        uint256 initValue = initAccount.value;
+        while (_index != 1 && initValue > _heap.accounts[_index / 2 - 1].value) {
+            set(_heap, _index, _heap.accounts[_index / 2 - 1]);
+            _index /= 2;
         }
+        set(_heap, _index, initAccount);
     }
 
     /// @notice Moves an account down the heap until its value is greater than the ones of its children.
@@ -111,31 +125,26 @@ library BasicHeap {
     /// @param _heap The heap to modify.
     /// @param _index The index of the account to move.
     function shiftDown(Heap storage _heap, uint256 _index) private {
-        uint256 accountsLength = _heap.accounts.length;
-        uint256 leftIndex;
-        uint256 rightIndex;
-        uint256 maxIndex;
-        uint256 maxValue;
+        uint256 size = _heap.accounts.length;
+        Account memory initAccount = _heap.accounts[_index - 1];
+        uint256 childIndex = _index * 2;
+        Account memory childAccount;
 
-        while (true) {
-            leftIndex = 2 * _index;
-            rightIndex = 2 * _index + 1;
-            maxIndex = _index;
-            maxValue = _heap.accounts[_index - 1].value;
+        while (childIndex <= size) {
+            if (
+                childIndex + 1 <= size &&
+                _heap.accounts[childIndex].value > _heap.accounts[childIndex - 1].value
+            ) childIndex++;
 
-            if (leftIndex <= accountsLength && _heap.accounts[leftIndex - 1].value > maxValue) {
-                maxIndex = leftIndex;
-                maxValue = _heap.accounts[leftIndex - 1].value;
-            }
+            childAccount = _heap.accounts[childIndex - 1];
 
-            if (rightIndex <= accountsLength && _heap.accounts[rightIndex - 1].value > maxValue)
-                maxIndex = rightIndex;
-
-            if (maxIndex != _index) {
-                swap(_heap, _index, maxIndex);
-                _index = maxIndex;
+            if (childAccount.value > initAccount.value) {
+                set(_heap, _index, childAccount);
+                _index = childIndex;
+                childIndex *= 2;
             } else break;
         }
+        set(_heap, _index, initAccount);
     }
 
     /// @notice Inserts an account in the `_heap`.

--- a/test-foundry/TestHeap.t.sol
+++ b/test-foundry/TestHeap.t.sol
@@ -233,4 +233,26 @@ contract TestHeap is DSTest {
             assertEq(prevAccount, accounts[10 - i - 2]);
         }
     }
+
+    function testDecrease1() public {
+        heap.update(accounts[0], 0, 4);
+        heap.update(accounts[1], 0, 3);
+        heap.update(accounts[2], 0, 2);
+        heap.update(accounts[0], 4, 1);
+
+        assertEq(heap.accounts[0].value, 3);
+        assertEq(heap.accounts[1].value, 1);
+        assertEq(heap.accounts[2].value, 2);
+    }
+
+    function testDecrease2() public {
+        heap.update(accounts[0], 0, 4);
+        heap.update(accounts[1], 0, 2);
+        heap.update(accounts[2], 0, 3);
+        heap.update(accounts[0], 4, 1);
+
+        assertEq(heap.accounts[0].value, 3);
+        assertEq(heap.accounts[1].value, 2);
+        assertEq(heap.accounts[2].value, 1);
+    }
 }

--- a/test-foundry/TestHeap.t.sol
+++ b/test-foundry/TestHeap.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+import "forge-std/Vm.sol";
+
+import "@contracts/Heap.sol";
+
+contract TestHeap is DSTest {
+    using BasicHeap for BasicHeap.Heap;
+
+    Vm public hevm = Vm(HEVM_ADDRESS);
+
+    uint256 public NDS = 50;
+    address[] public accounts;
+    address public ADDR_ZERO = address(0);
+
+    BasicHeap.Heap internal heap;
+
+    function setUp() public {
+        accounts = new address[](NDS);
+        accounts[0] = address(this);
+        for (uint256 i = 1; i < NDS; i++) {
+            accounts[i] = address(uint160(accounts[i - 1]) + 1);
+        }
+    }
+
+    function testInsertOneSingleAccount() public {
+        heap.update(accounts[0], 0, 1);
+
+        assertEq(heap.length(), 1);
+        assertEq(heap.getValueOf(accounts[0]), 1);
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[0]);
+        assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[0]), ADDR_ZERO);
+    }
+
+    function testShouldNotInsertAccountWithZeroValue() public {
+        heap.update(accounts[0], 0, 0);
+        assertEq(heap.length(), 0);
+    }
+
+    function testShouldNotInsertZeroAddress() public {
+        hevm.expectRevert(abi.encodeWithSignature("AddressIsZero()"));
+        heap.update(address(0), 0, 10);
+    }
+
+    function testShouldInsertSeveralTimesTheSameAccount() public {
+        heap.update(accounts[0], 0, 1);
+        heap.update(accounts[0], 1, 2);
+        assertEq(heap.getValueOf(accounts[0]), 2);
+    }
+
+    function testShouldHaveTheRightOrder() public {
+        heap.update(accounts[0], 0, 20);
+        heap.update(accounts[1], 0, 40);
+        assertEq(heap.getHead(), accounts[1]);
+        assertEq(heap.getTail(), accounts[0]);
+    }
+
+    function testShouldRemoveOneSingleAccount() public {
+        heap.update(accounts[0], 0, 1);
+        heap.update(accounts[0], 1, 0);
+
+        assertEq(heap.getHead(), ADDR_ZERO);
+        assertEq(heap.getTail(), ADDR_ZERO);
+        assertEq(heap.getValueOf(accounts[0]), 0);
+        assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[0]), ADDR_ZERO);
+    }
+
+    function testShouldInsertTwoAccounts() public {
+        heap.update(accounts[0], 0, 2);
+        heap.update(accounts[1], 0, 1);
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[1]);
+        assertEq(heap.getValueOf(accounts[0]), 2);
+        assertEq(heap.getValueOf(accounts[1]), 1);
+        assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[0]), accounts[1]);
+        assertEq(heap.getPrev(accounts[1]), accounts[0]);
+        assertEq(heap.getNext(accounts[1]), ADDR_ZERO);
+    }
+
+    function testShouldInsertThreeAccounts() public {
+        heap.update(accounts[0], 0, 3);
+        heap.update(accounts[1], 0, 2);
+        heap.update(accounts[2], 0, 1);
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[2]);
+        assertEq(heap.getValueOf(accounts[0]), 3);
+        assertEq(heap.getValueOf(accounts[1]), 2);
+        assertEq(heap.getValueOf(accounts[2]), 1);
+        assertEq(heap.getPrev(accounts[0]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[0]), accounts[1]);
+        assertEq(heap.getPrev(accounts[1]), accounts[0]);
+        assertEq(heap.getNext(accounts[1]), accounts[2]);
+        assertEq(heap.getPrev(accounts[2]), accounts[1]);
+        assertEq(heap.getNext(accounts[2]), ADDR_ZERO);
+    }
+
+    function testShouldRemoveOneAccountOverTwo() public {
+        heap.update(accounts[0], 0, 2);
+        heap.update(accounts[1], 0, 1);
+        heap.update(accounts[0], 2, 0);
+
+        assertEq(heap.getHead(), accounts[1]);
+        assertEq(heap.getTail(), accounts[1]);
+        assertEq(heap.getValueOf(accounts[0]), 0);
+        assertEq(heap.getValueOf(accounts[1]), 1);
+        assertEq(heap.getPrev(accounts[1]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[1]), ADDR_ZERO);
+    }
+
+    function testShouldRemoveBothAccounts() public {
+        heap.update(accounts[0], 0, 2);
+        heap.update(accounts[1], 0, 1);
+        heap.update(accounts[0], 2, 0);
+        heap.update(accounts[1], 1, 0);
+
+        assertEq(heap.getHead(), ADDR_ZERO);
+        assertEq(heap.getTail(), ADDR_ZERO);
+    }
+
+    function testShouldInsertThreeAccountsAndRemoveThem() public {
+        heap.update(accounts[0], 0, 3);
+        heap.update(accounts[1], 0, 2);
+        heap.update(accounts[2], 0, 1);
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[2]);
+
+        // Remove account 0.
+        heap.update(accounts[0], 3, 0);
+        assertEq(heap.getHead(), accounts[1]);
+        assertEq(heap.getTail(), accounts[2]);
+        assertEq(heap.getPrev(accounts[1]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[1]), accounts[2]);
+
+        assertEq(heap.getPrev(accounts[2]), accounts[1]);
+        assertEq(heap.getNext(accounts[2]), ADDR_ZERO);
+
+        // Remove account 1.
+        heap.update(accounts[1], 2, 0);
+        assertEq(heap.getHead(), accounts[2]);
+        assertEq(heap.getTail(), accounts[2]);
+        assertEq(heap.getPrev(accounts[2]), ADDR_ZERO);
+        assertEq(heap.getNext(accounts[2]), ADDR_ZERO);
+
+        // Remove account 2.
+        heap.update(accounts[2], 1, 0);
+        assertEq(heap.getHead(), ADDR_ZERO);
+        assertEq(heap.getTail(), ADDR_ZERO);
+    }
+
+    function testShouldInsertAccountsAllSorted() public {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            heap.update(accounts[i], 0, NDS - i);
+        }
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[accounts.length - 1]);
+
+        address nextAccount = accounts[0];
+        for (uint256 i = 0; i < accounts.length - 1; i++) {
+            nextAccount = heap.getNext(nextAccount);
+            assertEq(nextAccount, accounts[i + 1]);
+        }
+
+        address prevAccount = accounts[accounts.length - 1];
+        for (uint256 i = 0; i < accounts.length - 1; i++) {
+            prevAccount = heap.getPrev(prevAccount);
+            assertEq(prevAccount, accounts[accounts.length - i - 2]);
+        }
+    }
+
+    function testShouldRemoveAllSortedAccount() public {
+        for (uint256 i = 0; i < accounts.length; i++) {
+            heap.update(accounts[i], 0, NDS - i);
+        }
+
+        for (uint256 i = 0; i < accounts.length; i++) {
+            heap.update(accounts[i], NDS - i, 0);
+        }
+
+        assertEq(heap.getHead(), ADDR_ZERO);
+        assertEq(heap.getTail(), ADDR_ZERO);
+    }
+
+    function testShouldInsertAccountSortedAtTheBeginningUntilNDS() public {
+        uint256 value = 50;
+
+        // Add first 10 accounts with decreasing value.
+        for (uint256 i = 0; i < 10; i++) {
+            heap.update(accounts[i], 0, value - i);
+        }
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[9]);
+
+        address nextAccount = accounts[0];
+        for (uint256 i = 0; i < 9; i++) {
+            nextAccount = heap.getNext(nextAccount);
+            assertEq(nextAccount, accounts[i + 1]);
+        }
+
+        address prevAccount = accounts[9];
+        for (uint256 i = 0; i < 9; i++) {
+            prevAccount = heap.getPrev(prevAccount);
+            assertEq(prevAccount, accounts[10 - i - 2]);
+        }
+
+        // Add last 10 accounts at the same value.
+        for (uint256 i = NDS - 10; i < NDS; i++) {
+            heap.update(accounts[i], 0, 10);
+        }
+
+        assertEq(heap.getHead(), accounts[0]);
+        assertEq(heap.getTail(), accounts[accounts.length - 1]);
+
+        nextAccount = accounts[0];
+        for (uint256 i = 0; i < 9; i++) {
+            nextAccount = heap.getNext(nextAccount);
+            assertEq(nextAccount, accounts[i + 1]);
+        }
+
+        prevAccount = accounts[9];
+        for (uint256 i = 0; i < 9; i++) {
+            prevAccount = heap.getPrev(prevAccount);
+            assertEq(prevAccount, accounts[10 - i - 2]);
+        }
+    }
+}

--- a/test-foundry/TestHeap.t.sol
+++ b/test-foundry/TestHeap.t.sol
@@ -28,7 +28,7 @@ contract TestHeap is DSTest {
     function testInsertOneSingleAccount() public {
         heap.update(accounts[0], 0, 1);
 
-        assertEq(heap.length(), 1);
+        assertEq(heap.getSize(), 1);
         assertEq(heap.getValueOf(accounts[0]), 1);
         assertEq(heap.getHead(), accounts[0]);
         assertEq(heap.getTail(), accounts[0]);
@@ -38,7 +38,7 @@ contract TestHeap is DSTest {
 
     function testShouldNotInsertAccountWithZeroValue() public {
         heap.update(accounts[0], 0, 0);
-        assertEq(heap.length(), 0);
+        assertEq(heap.getSize(), 0);
     }
 
     function testShouldNotInsertZeroAddress() public {
@@ -198,19 +198,19 @@ contract TestHeap is DSTest {
             heap.update(accounts[i], 0, value - i);
         }
 
-        assertEq(heap.getHead(), accounts[0]);
-        assertEq(heap.getTail(), accounts[9]);
+        assertEq(heap.getHead(), accounts[0], "head not expected, 1");
+        assertEq(heap.getTail(), accounts[9], "tail not expected, 1");
 
         address nextAccount = accounts[0];
         for (uint256 i = 0; i < 9; i++) {
             nextAccount = heap.getNext(nextAccount);
-            assertEq(nextAccount, accounts[i + 1]);
+            assertEq(nextAccount, accounts[i + 1], "next not expected, 1");
         }
 
         address prevAccount = accounts[9];
         for (uint256 i = 0; i < 9; i++) {
             prevAccount = heap.getPrev(prevAccount);
-            assertEq(prevAccount, accounts[10 - i - 2]);
+            assertEq(prevAccount, accounts[10 - i - 2], "prev not expected, 1");
         }
 
         // Add last 10 accounts at the same value.
@@ -218,19 +218,19 @@ contract TestHeap is DSTest {
             heap.update(accounts[i], 0, 10);
         }
 
-        assertEq(heap.getHead(), accounts[0]);
-        assertEq(heap.getTail(), accounts[accounts.length - 1]);
+        assertEq(heap.getHead(), accounts[0], "head not expected, 2");
+        assertEq(heap.getTail(), accounts[accounts.length - 1], "tail not expected, 2");
 
         nextAccount = accounts[0];
         for (uint256 i = 0; i < 9; i++) {
             nextAccount = heap.getNext(nextAccount);
-            assertEq(nextAccount, accounts[i + 1]);
+            assertEq(nextAccount, accounts[i + 1], "next not expected, 2");
         }
 
         prevAccount = accounts[9];
         for (uint256 i = 0; i < 9; i++) {
             prevAccount = heap.getPrev(prevAccount);
-            assertEq(prevAccount, accounts[10 - i - 2]);
+            assertEq(prevAccount, accounts[10 - i - 2], "prev not expected, 2");
         }
     }
 

--- a/test-foundry/TestStressHeap.t.sol
+++ b/test-foundry/TestStressHeap.t.sol
@@ -9,6 +9,7 @@ import "@contracts/Heap.sol";
 contract HeapStorage {
     BasicHeap.Heap internal heap;
     uint256 public TESTED_SIZE = 10000;
+    uint256 public incrementAmount = 5;
 
     function setUp() public {
         for (uint256 i = 0; i < TESTED_SIZE; i++) {
@@ -30,10 +31,12 @@ contract HeapStorage {
 contract TestStressHeap is DSTest {
     HeapStorage public hs = new HeapStorage();
     uint256 public ts;
+    uint256 public im;
 
     function setUp() public {
         hs.setUp();
         ts = hs.TESTED_SIZE();
+        im = hs.incrementAmount();
     }
 
     function testInsertOneTop() public {
@@ -58,22 +61,22 @@ contract TestStressHeap is DSTest {
     }
 
     function testRemoveOneBottom() public {
-        uint256 end = ts - 10;
+        uint256 end = ts - 2 * im;
         hs.update(address(uint160(end + 1)), ts - end, 0);
     }
 
     function testIncreaseOneTop() public {
-        hs.update(address(uint160(1)), ts, ts + 5);
+        hs.update(address(uint160(1)), ts, ts + im);
     }
 
     function testIncreaseOneMiddle() public {
         uint256 middle = ts / 2;
-        hs.update(address(uint160(middle + 1)), ts - middle, ts - middle + 5);
+        hs.update(address(uint160(middle + 1)), ts - middle, ts - middle + im);
     }
 
     function testIncreaseOneBottom() public {
-        uint256 end = ts - 10;
-        hs.update(address(uint160(end + 1)), ts - end, ts - end + 5);
+        uint256 end = ts - 2 * im;
+        hs.update(address(uint160(end + 1)), ts - end, ts - end + im);
     }
 
     function testDecreaseOneTop() public {
@@ -86,7 +89,7 @@ contract TestStressHeap is DSTest {
     }
 
     function testDecreaseOneBottom() public {
-        uint256 end = ts - 10;
-        hs.update(address(uint160(end + 1)), ts - end, ts - end - 5);
+        uint256 end = ts - 2 * im;
+        hs.update(address(uint160(end + 1)), ts - end, ts - end - im);
     }
 }

--- a/test-foundry/TestStressHeap.t.sol
+++ b/test-foundry/TestStressHeap.t.sol
@@ -18,12 +18,20 @@ contract HeapStorage {
         }
     }
 
-    function update(
-        address _id,
-        uint256 _formerValue,
-        uint256 _newValue
-    ) public {
-        BasicHeap.update(heap, _id, _formerValue, _newValue);
+    function insert(address _id, uint256 _value) public {
+        BasicHeap.insert(heap, _id, _value);
+    }
+
+    function decrease(address _id, uint256 _newValue) public {
+        BasicHeap.decrease(heap, _id, _newValue);
+    }
+
+    function increase(address _id, uint256 _newValue) public {
+        BasicHeap.increase(heap, _id, _newValue);
+    }
+
+    function remove(address _id) public {
+        BasicHeap.remove(heap, _id);
     }
 }
 
@@ -39,56 +47,56 @@ contract TestStressHeap is DSTest {
     }
 
     function testInsertOneTop() public {
-        hs.update(address(this), 0, ts + 1);
+        hs.insert(address(this), ts + 1);
     }
 
     function testInsertOneMiddle() public {
-        hs.update(address(this), 0, ts / 2);
+        hs.insert(address(this), ts / 2);
     }
 
     function testInsertOneBottom() public {
-        hs.update(address(this), 0, 1);
+        hs.insert(address(this), 1);
     }
 
     function testRemoveOneTop() public {
-        hs.update(address(uint160(1)), ts, 0);
+        hs.remove(address(uint160(1)));
     }
 
     function testRemoveOneMiddle() public {
         uint256 middle = ts / 2;
-        hs.update(address(uint160(middle + 1)), ts - middle, 0);
+        hs.remove(address(uint160(middle + 1)));
     }
 
     function testRemoveOneBottom() public {
         uint256 end = ts - 2 * im;
-        hs.update(address(uint160(end + 1)), ts - end, 0);
+        hs.remove(address(uint160(end + 1)));
     }
 
     function testIncreaseOneTop() public {
-        hs.update(address(uint160(1)), ts, ts + im);
+        hs.increase(address(uint160(1)), ts + im);
     }
 
     function testIncreaseOneMiddle() public {
         uint256 middle = ts / 2;
-        hs.update(address(uint160(middle + 1)), ts - middle, ts - middle + im);
+        hs.increase(address(uint160(middle + 1)), ts - middle + im);
     }
 
     function testIncreaseOneBottom() public {
         uint256 end = ts - 2 * im;
-        hs.update(address(uint160(end + 1)), ts - end, ts - end + im);
+        hs.increase(address(uint160(end + 1)), ts - end + im);
     }
 
     function testDecreaseOneTop() public {
-        hs.update(address(uint160(1)), ts, 1);
+        hs.decrease(address(uint160(1)), 1);
     }
 
     function testDecreaseOneMiddle() public {
         uint256 middle = ts / 2;
-        hs.update(address(uint160(middle + 1)), ts - middle, 1);
+        hs.decrease(address(uint160(middle + 1)), 1);
     }
 
     function testDecreaseOneBottom() public {
         uint256 end = ts - 2 * im;
-        hs.update(address(uint160(end + 1)), ts - end, ts - end - im);
+        hs.decrease(address(uint160(end + 1)), ts - end - im);
     }
 }

--- a/test-foundry/TestStressHeap.t.sol
+++ b/test-foundry/TestStressHeap.t.sol
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+import "ds-test/test.sol";
+import "forge-std/console.sol";
+
+import "@contracts/Heap.sol";
+
+contract HeapStorage {
+    BasicHeap.Heap internal heap;
+    uint256 public TESTED_SIZE = 10000;
+
+    function setUp() public {
+        for (uint256 i = 0; i < TESTED_SIZE; i++) {
+            address id = address(uint160(i + 1));
+            heap.accounts.push(BasicHeap.Account(id, TESTED_SIZE - i));
+            heap.indexes[id] = heap.accounts.length;
+        }
+    }
+
+    function update(
+        address _id,
+        uint256 _formerValue,
+        uint256 _newValue
+    ) public {
+        BasicHeap.update(heap, _id, _formerValue, _newValue);
+    }
+}
+
+contract TestStressHeap is DSTest {
+    HeapStorage public hs = new HeapStorage();
+    uint256 public ts;
+
+    function setUp() public {
+        hs.setUp();
+        ts = hs.TESTED_SIZE();
+    }
+
+    function testInsertOneTop() public {
+        hs.update(address(this), 0, ts + 1);
+    }
+
+    function testInsertOneMiddle() public {
+        hs.update(address(this), 0, ts / 2);
+    }
+
+    function testInsertOneBottom() public {
+        hs.update(address(this), 0, 1);
+    }
+
+    function testRemoveOneTop() public {
+        hs.update(address(uint160(1)), ts, 0);
+    }
+
+    function testRemoveOneMiddle() public {
+        uint256 middle = ts / 2;
+        hs.update(address(uint160(middle + 1)), ts - middle, 0);
+    }
+
+    function testRemoveOneBottom() public {
+        uint256 end = ts - 10;
+        hs.update(address(uint160(end + 1)), ts - end, 0);
+    }
+
+    function testIncreaseOneTop() public {
+        hs.update(address(uint160(1)), ts, ts + 5);
+    }
+
+    function testIncreaseOneMiddle() public {
+        uint256 middle = ts / 2;
+        hs.update(address(uint160(middle + 1)), ts - middle, ts - middle + 5);
+    }
+
+    function testIncreaseOneBottom() public {
+        uint256 end = ts - 10;
+        hs.update(address(uint160(end + 1)), ts - end, ts - end + 5);
+    }
+
+    function testDecreaseOneTop() public {
+        hs.update(address(uint160(1)), ts, 1);
+    }
+
+    function testDecreaseOneMiddle() public {
+        uint256 middle = ts / 2;
+        hs.update(address(uint160(middle + 1)), ts - middle, 1);
+    }
+
+    function testDecreaseOneBottom() public {
+        uint256 end = ts - 10;
+        hs.update(address(uint160(end + 1)), ts - end, ts - end - 5);
+    }
+}

--- a/test-foundry/TestStressHeap.t.sol
+++ b/test-foundry/TestStressHeap.t.sol
@@ -14,7 +14,7 @@ contract HeapStorage {
         for (uint256 i = 0; i < TESTED_SIZE; i++) {
             address id = address(uint160(i + 1));
             heap.accounts.push(BasicHeap.Account(id, TESTED_SIZE - i));
-            heap.indexes[id] = heap.accounts.length;
+            heap.ranks[id] = heap.accounts.length;
         }
     }
 

--- a/test-foundry/TestStressHeap.t.sol
+++ b/test-foundry/TestStressHeap.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "ds-test/test.sol";
-import "forge-std/console.sol";
 
 import "@contracts/Heap.sol";
 


### PR DESCRIPTION
This implements a heap as the data structure for the matching engine. The implementation uses a "basic" heap in the sense that its elements are simply stored in an array with the following rules for the indexes:

- they start from index `1` and end at the length of the array (included)
- index `0` is used for checking if elements are not in the heap
- from index `i`, go to the left child with `2 * i`
- from index `i`, go to the right child with `2 * i + 1`
- from index `i`, go to the parent with `i / 2`

There is an address as satellite data `id`, that can be used, for example, to retrieve whose account has the biggest amount. There is also a mapping `indexes` from addresses to indexes in the array, allowing us to access the account associated to a given address.

The only non-view, non-private function is the function `update`. According to the parameters it receives, it calls one of the private functions `insert`, `decrease`, `increase` or `remove`.