### PR TITLE
perf: Pack heap size + array length

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -242,12 +242,13 @@ library HeapOrdering {
         uint128 accountsLength = _heap.arrayLength;
 
         // Swap the last account and the account to remove, then pop it.
-        swap(_heap, index, accountsLength - 1);
+        uint128 newArrayLength = accountsLength - 1;
+        swap(_heap, index, newArrayLength);
         unchecked {
             // accountsLength - 1 is performed in the line above, so these cannot underflow.
-            delete _heap.accounts[accountsLength - 1];
-            _heap.arrayLength = accountsLength - 1;
-            if (_heap.size == accountsLength) _heap.size = accountsLength - 1;
+            delete _heap.accounts[newArrayLength];
+            _heap.arrayLength = newArrayLength;
+            if (_heap.size == accountsLength) _heap.size = newArrayLength;
         }
         delete _heap.indexOf[_id];
 

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -14,7 +14,7 @@ contract TestHeapOrdering is DSTest {
 
     address[] public accounts;
     uint256 public NB_ACCOUNTS = 50;
-    uint256 public MAX_SORTED_USERS = 50;
+    uint128 public MAX_SORTED_USERS = 50;
     address public ADDR_ZERO = address(0);
 
     HeapOrdering.HeapArray internal heap;
@@ -420,7 +420,7 @@ contract TestHeapOrdering is DSTest {
 
         for (uint256 i = 10; i < 15; i++) update(accounts[i], 0, i - 9);
 
-        for (uint256 i = 10; i < 15; i++) assertLe(heap.accounts[i].value, 10);
+        for (uint128 i = 10; i < 15; i++) assertLe(heap.accounts[i].value, 10);
     }
 
     function testInsertWrap() public {
@@ -488,7 +488,7 @@ contract TestHeapOrdering is DSTest {
         uint256 sizeAfter = heap.size;
 
         assertLt(sizeAfter, sizeBefore);
-        assertEq(heap.accounts.length, 2);
+        assertEq(heap.arrayLength, 2);
     }
 
     function testRemoveShiftDown() public {

--- a/test-foundry/TestRandomHeapOrdering.t.sol
+++ b/test-foundry/TestRandomHeapOrdering.t.sol
@@ -43,7 +43,7 @@ contract Helper is Random {
     function updateHeap(
         address _id,
         uint256 _newValue,
-        uint256 _max_sorted_users
+        uint128 _max_sorted_users
     ) public {
         HeapOrdering.HeapArray storage heap = getCurrentHeap();
         uint256 formerValue = HeapOrdering.getValueOf(heap, _id);
@@ -59,11 +59,11 @@ contract Helper is Random {
         // Check that for the parent value (at rank i) is always greater than the ones of his children
         // (at rank 2i, 2i + 1), for ranks <= head size
         HeapOrdering.HeapArray storage heap = getCurrentHeap();
-        for (uint256 rank = 1; rank < getSize(); rank++) {
+        for (uint128 rank = 1; rank < getSize(); rank++) {
             HeapOrdering.Account memory user = heap.accounts[rank - 1];
             // child = 0 (left) or child = 1 (right)
-            for (uint256 child; child <= 1; child++) {
-                uint256 childRank = rank * 2 + child;
+            for (uint128 child; child <= 1; child++) {
+                uint128 childRank = rank * 2 + child;
                 if (childRank <= getSize()) {
                     HeapOrdering.Account memory childUser = heap.accounts[childRank - 1];
                     require(
@@ -87,7 +87,7 @@ contract TestHeapRandomHeapOrdering is DSTest {
         uint256 N_USERS = n;
         uint256 RANGE_VALUES = 2 * n;
         uint256 N_ITERS = 3 * n;
-        uint256 max_sorted_users = helper.randomUint256(N_USERS);
+        uint128 max_sorted_users = uint128(helper.randomUint256(N_USERS));
         for (uint256 iter; iter < N_ITERS; iter++) {
             address user = helper.randomAddress(N_USERS);
             uint256 newValue;
@@ -97,7 +97,7 @@ contract TestHeapRandomHeapOrdering is DSTest {
             }
             if (helper.randomUint256(N_ITERS) <= 3) {
                 // change max users approximately 3 times per test
-                max_sorted_users = helper.randomUint256(N_USERS);
+                max_sorted_users = uint128(helper.randomUint256(N_USERS));
             }
             helper.updateHeap(user, newValue, max_sorted_users);
         }

--- a/test-foundry/TestStessHeapOrdering.t.sol
+++ b/test-foundry/TestStessHeapOrdering.t.sol
@@ -7,15 +7,16 @@ import "@contracts/HeapOrdering.sol";
 
 contract HeapStorage {
     HeapOrdering.HeapArray internal heap;
-    uint256 public TESTED_SIZE = 10000;
-    uint256 public MAX_SORTED_USERS = TESTED_SIZE;
+    uint128 public TESTED_SIZE = 10000;
+    uint128 public MAX_SORTED_USERS = TESTED_SIZE;
     uint256 public incrementAmount = 5;
 
     function setUp() public {
         for (uint256 i = 0; i < TESTED_SIZE; i++) {
             address id = address(uint160(i + 1));
-            heap.indexOf[id] = heap.accounts.length;
-            heap.accounts.push(HeapOrdering.Account(id, uint96(TESTED_SIZE - i)));
+            heap.indexOf[id] = heap.arrayLength;
+            heap.accounts[heap.arrayLength] = HeapOrdering.Account(id, uint96(TESTED_SIZE - i));
+            heap.arrayLength++;
             heap.size = MAX_SORTED_USERS;
         }
     }


### PR DESCRIPTION
Replaces the `HeapArray.accounts` array with a "virtual array" consisting of a mapping and a `uint128` length. This lets us pack the array length and heap size into the same storage slot. Note that this trick also works for 3-heap

## Gas Before 
![Screen Shot 2022-10-10 at 2 28 18 PM](https://user-images.githubusercontent.com/8365992/194940647-ab415e46-be7a-44db-927a-ac91da9080a2.png)

## Gas After
![Screen Shot 2022-10-10 at 2 44 14 PM](https://user-images.githubusercontent.com/8365992/194940667-ac7199b9-a33d-4e9b-9eb4-920a9cde6606.png)

