### PR TITLE
Fix shift guard in decrease

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -198,7 +198,7 @@ library HeapOrdering {
         uint256 index = _heap.indexOf[_id];
         _heap.accounts[index].value = _newValue;
 
-        // We only need to restore the invariant if the account is a node in the heap
+        // We only need to take care of sorting if there are nodes below in the heap.
         if (index < _heap.size >> 1) shiftDown(_heap, index);
     }
 

--- a/contracts/ThreeHeapOrdering.sol
+++ b/contracts/ThreeHeapOrdering.sol
@@ -183,7 +183,8 @@ library ThreeHeapOrdering {
     ) private {
         uint256 index = _heap.indexOf[_id];
 
-        if (index < (_heap.size - 1) / 3) shiftDown(_heap, Account(_id, _newValue), index);
+        // We only need to take care of sorting if there are nodes below in the heap.
+        if (3 * index + 1 < _heap.size) shiftDown(_heap, Account(_id, _newValue), index);
         else _heap.accounts[index].value = _newValue;
     }
 

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -125,6 +125,23 @@ contract TestHeapOrdering is CommonHeapOrdering {
         assertEq(heap.accountsValue(5), 10);
     }
 
+    function testDecreaseGuardLimit() public {
+        update(accounts[0], 0, 20);
+        update(accounts[1], 0, 19);
+        update(accounts[2], 0, 18);
+        update(accounts[3], 0, 17);
+
+        assertEq(heap.accountsValue(0), 20);
+        assertEq(heap.accountsValue(1), 19);
+        assertEq(heap.accountsValue(2), 18);
+        assertEq(heap.accountsValue(3), 17);
+
+        update(accounts[1], 19, 1);
+
+        assertEq(heap.accountsValue(1), 17);
+        assertEq(heap.accountsValue(3), 1);
+    }
+
     function testInsertWrap() public {
         MAX_SORTED_USERS = 20;
         for (uint256 i = 0; i < 20; i++) update(accounts[i], 0, NB_ACCOUNTS - i);

--- a/test-foundry/TestThreeHeapOrdering.t.sol
+++ b/test-foundry/TestThreeHeapOrdering.t.sol
@@ -195,6 +195,31 @@ contract TestThreeHeapOrdering is CommonHeapOrdering {
         assertEq(heap.accountsValue(5), 1);
     }
 
+    function testDecreaseGuardLimit() public {
+        update(accounts[0], 0, 20);
+        update(accounts[1], 0, 19);
+        update(accounts[2], 0, 18);
+        update(accounts[3], 0, 17);
+        update(accounts[4], 0, 16);
+        update(accounts[5], 0, 15);
+        update(accounts[6], 0, 14);
+        update(accounts[7], 0, 13);
+
+        assertEq(heap.accountsValue(0), 20);
+        assertEq(heap.accountsValue(1), 19);
+        assertEq(heap.accountsValue(2), 18);
+        assertEq(heap.accountsValue(3), 17);
+        assertEq(heap.accountsValue(4), 16);
+        assertEq(heap.accountsValue(5), 15);
+        assertEq(heap.accountsValue(6), 14);
+        assertEq(heap.accountsValue(7), 13);
+
+        update(accounts[2], 18, 1);
+
+        assertEq(heap.accountsValue(2), 13);
+        assertEq(heap.accountsValue(7), 1);
+    }
+
     function testInsertWrap() public {
         MAX_SORTED_USERS = 30;
         for (uint256 i = 0; i < 30; i++) update(accounts[i], 0, NB_ACCOUNTS - i);


### PR DESCRIPTION
### Problem
We want to skip `shiftDown` when there are no elements below it in the heap part of the data-structure. 

### Solution

Just check if the first son is in the heap part of the data-structure. This corresponds to `leftMostChildIndex(index) < _heap.size`.

For the 3-heap, this is simply `3 * index + 1 < _heap.size`.

For the 2-heap, this can be checked more efficiently with `index < _heap.size / 2`. This comes from the following general theorem:
$\forall m ~n \in \mathbb{N}. m < \frac{n}{2} \Leftrightarrow 2m + 1 < n$



### Other checks
The following ways to check (for the 3-heap) don't work. 
1. `index < (_heap.size - 1) / 3`
2. `index < _heap.size / 3`

See the added test `testDecreaseGuardLimit` for a counter-example.