### PR TITLE
Correct testing behavior for safe cast

### DIFF
--- a/test-foundry/TestCommonHeapOrdering.t.sol
+++ b/test-foundry/TestCommonHeapOrdering.t.sol
@@ -338,11 +338,11 @@ abstract contract TestCommonHeapOrdering is Test {
 
     function testOverflowNewValue() public {
         vm.expectRevert("SafeCast: value doesn't fit in 96 bits");
-        update(accounts[0], 0, uint256(type(uint128).max));
+        update(accounts[0], 0, uint256(type(uint96).max) + 1);
     }
 
     function testOverflowFormerValue() public {
         vm.expectRevert("SafeCast: value doesn't fit in 96 bits");
-        update(accounts[0], uint256(type(uint128).max), 0);
+        update(accounts[0], uint256(type(uint96).max) + 1, 0);
     }
 }

--- a/test-foundry/TestCommonHeapOrdering.t.sol
+++ b/test-foundry/TestCommonHeapOrdering.t.sol
@@ -336,13 +336,17 @@ abstract contract TestCommonHeapOrdering is Test {
         assertEq(heap.indexOf(accounts[3]), 3);
     }
 
-    function testOverflowNewValue() public {
+    function testOverflowNewValue(uint256 value) public {
+        vm.assume(value > type(uint96).max);
+
         vm.expectRevert("SafeCast: value doesn't fit in 96 bits");
-        update(accounts[0], 0, uint256(type(uint96).max) + 1);
+        update(accounts[0], 0, value);
     }
 
-    function testOverflowFormerValue() public {
+    function testOverflowFormerValue(uint256 value) public {
+        vm.assume(value > type(uint96).max);
+
         vm.expectRevert("SafeCast: value doesn't fit in 96 bits");
-        update(accounts[0], uint256(type(uint96).max) + 1, 0);
+        update(accounts[0], value, 0);
     }
 }


### PR DESCRIPTION
Forme tests where testing for the wrong value (`uint128` instead of `uint96`)