### PR TITLE
Revert "Fix getNext(unkown)"

### DIFF
--- a/contracts/HeapOrdering.sol
+++ b/contracts/HeapOrdering.sol
@@ -327,8 +327,7 @@ library HeapOrdering {
     /// @return The address of the next account.
     function getNext(HeapArray storage _heap, address _id) internal view returns (address) {
         uint256 rank = _heap.ranks[_id];
-        if (rank == 0 || rank >= _heap.accounts.length) return address(0);
-
-        return getAccount(_heap, rank + 1).id;
+        if (rank < _heap.accounts.length) return getAccount(_heap, rank + 1).id;
+        else return address(0);
     }
 }

--- a/test-foundry/TestHeapOrdering.t.sol
+++ b/test-foundry/TestHeapOrdering.t.sol
@@ -546,9 +546,4 @@ contract TestHeapOrdering is DSTest {
         hevm.expectRevert("SafeCast: value doesn't fit in 96 bits");
         update(accounts[0], uint256(type(uint128).max), 0);
     }
-
-    function testGetNextUnknown() public {
-        update(accounts[0], 0, 1);
-        assertEq(heap.getNext(address(0xdEaD)), ADDR_ZERO);
-    }
 }


### PR DESCRIPTION
This reverts commit 1702aacdb9725f429cff3d28e410f6f2a7c8d1a5 introduced in https://github.com/morpho-dao/morpho-data-structures/pull/93, because we don't want this commit included in the `morpho-v1` branch for now as it's not deployed
Instead, we want this commit on this repository's next upgrade's branch `upgrade-morpho-1`, referenced in the `morpho-v1` repository's `upgrade-morpho-1` branch